### PR TITLE
Change property to get notes counter

### DIFF
--- a/parsers/tumblr/parser.py
+++ b/parsers/tumblr/parser.py
@@ -74,7 +74,7 @@ class Parser(BaseParser):
         created_at = self._parse_date(post["date"])
         media = self._extract_media(post)
 
-        metrics = [f"💬 {self.format_counter(post.get('notes', 0))}"]
+        metrics = [f"💬 {self.format_counter(post.get('note_count', 0))}"]
         backlink = Link(post["post_url"])
 
         return Content(


### PR DESCRIPTION
## Summary

Fix Tumblr parser using wrong property name for notes counter — `note_count` instead of `notes`.

## Type of change
- [x] Bug fix

## Checklist
- [x] `pytest` passes
- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] Added/updated tests where it makes sense